### PR TITLE
ASG codes

### DIFF
--- a/cloudcompose/cluster/aws/cloudcontroller.py
+++ b/cloudcompose/cluster/aws/cloudcontroller.py
@@ -120,7 +120,7 @@ class CloudController:
         asg_name      = self.cluster_name
         vpc_zones     = self.aws['asg']['subnets']
         cluster_size  = len(vpc_zones.split(','))
-        redundancy    = self.aws['asg']['redundancy']
+        redundancy    = self.aws['asg'].get('redundancy', 1)
         lc_name       = self._build_launch_config(block_device_map, cloud_init)
         term_policies = ["OldestLaunchConfiguration", "OldestInstance", "Default"]
         instance_tags = self._build_instance_tags(None, {})

--- a/cloudcompose/cluster/aws/cloudcontroller.py
+++ b/cloudcompose/cluster/aws/cloudcontroller.py
@@ -116,10 +116,8 @@ class CloudController:
 
     def _create_asg(self, block_device_map, cloud_init):
         kwargs = self._create_asg_args(block_device_map)
-        print 'creating asg'
-        print kwargs
         try:
-            self.asg.create_auto_scaling_group(**kwargs)
+            code = self._asg_create(**kwargs)
             print 'created AutoScalingGroup with name %s' % self.cluster_name
         except botocore.exceptions.ClientError as ex:
             raise ex
@@ -293,6 +291,10 @@ class CloudController:
             raise ex
 
         return response
+
+    @retry(retry_on_exception=_is_retryable_exception, stop_max_delay=10000, wait_exponential_multiplier=500, wait_exponential_max=2000)
+    def _asg_create(self, **kwargs):
+        return self.asg.create_auto_scaling_group(**kwargs)
 
     @retry(retry_on_exception=_is_retryable_exception, stop_max_delay=10000, wait_exponential_multiplier=500, wait_exponential_max=2000)
     def _ec2_create_tags(self, **kwargs):

--- a/cloudcompose/cluster/aws/cloudcontroller.py
+++ b/cloudcompose/cluster/aws/cloudcontroller.py
@@ -118,12 +118,14 @@ class CloudController:
 
     def _create_asg_args(self, block_device_map, cloud_init):
         asg_name      = self.cluster_name
-        vpc_zones     = self.aws['asg']['subnets']
-        cluster_size  = len(vpc_zones.split(','))
+        subnet_list   = self.aws['asg']['subnets']
+        vpc_zones     = ', '.join(subnet_list)
+        cluster_size  = len(subnet_list)
         redundancy    = self.aws['asg'].get('redundancy', 1)
         lc_name       = self._build_launch_config(block_device_map, cloud_init)
         term_policies = ["OldestLaunchConfiguration", "OldestInstance", "Default"]
         instance_tags = self._build_instance_tags(None, {})
+
         return {
             'AutoScalingGroupName': asg_name,
             'LaunchConfigurationName': lc_name,

--- a/cloudcompose/cluster/cloudinit.py
+++ b/cloudcompose/cluster/cloudinit.py
@@ -10,11 +10,10 @@ class CloudInit():
         self.template_file = 'cluster.sh'
 
     def build(self, **kwargs):
-        config_data = self.cloud_config.config_data('cluster')
+        config_data = self.cloud_config.config_data('cluster')[0]
         raw_search_path = config_data['search_path']
         raw_search_path.insert(0, '.')
         search_path = [join(self.base_dir, path) for path in raw_search_path]
-
         for key, value in kwargs.iteritems():
             config_data['_' + key] = value
 

--- a/cloudcompose/cluster/commands/cli.py
+++ b/cloudcompose/cluster/commands/cli.py
@@ -32,6 +32,15 @@ def down():
     cloud_controller.down()
 
 @cli.command()
+def cleanup():
+    """
+    deletes launch configs and auto scaling group
+    """
+    cloud_config = CloudConfig()
+    cloud_controller = CloudController(cloud_config)
+    cloud_controller.cleanup()
+
+@cli.command()
 def build():
     """
     builds the cloud_init script


### PR DESCRIPTION
So asg lines in cloud-compose.yml looks like this:
```
...
asg:
  subnets: subnet-28573d71, subnet-4cb1e03b
  redundancy: 2
```
Cluster size creation is size to the number of subnets. To make sure there isn't an odd number of instances to zones I have that redundancy option which makes `cluster size = (# of subnets) * (redundancy #)`. Let me know if thats cool.

There is also no cleanup code for LC and ASG deletion which is kind of annoying. I can add that quickly sometime today.