### PR TITLE
Cloud compose image

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The ``search_path`` is the directories that will be examined when looking for co
 The AWS section contains information needed to create the cluster on AWS.
 
 ##### ami
-The ``ami`` is the Amazon Machine Image to start the EC2 servers from before installing the Docker containers that you want to run on these servers.
+The ``ami`` is the Amazon Machine Image to start the EC2 servers from before installing the Docker containers that you want to run on these servers. The ``ami`` can either be an AMI ID (e.g. ami-1234567) or the Name tag applied to the AMI (e.g. docker:1.10). If the same Name tag exists on multiple images the newest image will be selected when creating a new cluster. If the cluster is being upgraded and is not an autoscaling group, then the Name tag will resolve to the same image in use by other cluster nodes. This will ensure that all nodes are running the same image. To override this behavior and resolve the Namge tag to the latest version regardless of whether cluster nodes will be consistent, use the --upgrade-image option on the cluster up command. Autoscaling group clusters are always upgrade to the latest image when using the Name tag reference because the launch config already provides a way for restoring cluster nodes such that all instances have the same image.
 
 ##### username
 The ``username`` is used by the ``cluster.sh`` script to start the Docker containers using that user account.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ cluster:
     username: ${IMAGE_USERNAME}
     terminate_protection: false
     security_groups: ${SECURITY_GROUP_ID}
-    vpc: ${VPC_ID}
     ebs_optimized: false
     instance_type: t2.medium
     keypair: drydock
@@ -100,9 +99,6 @@ The ``username`` is used by the ``cluster.sh`` script to start the Docker contai
 
 ##### security
 The list of ``security_groups`` that should be added to the EC2 servers.
-
-##### vpc
-The ``vpc`` identifier to launch the EC2 servers in.
 
 ##### ebs_optimized (optional)
 Set ``ebs_optimized`` to true if you want EC2 servers with this featured turned on. The default value is false.

--- a/cloudcompose/cluster/aws/cloudcontroller.py
+++ b/cloudcompose/cluster/aws/cloudcontroller.py
@@ -5,7 +5,7 @@ from cloudcompose.exceptions import CloudComposeException
 from iam import InstancePolicyController
 from ebs import EBSController
 from cloudwatch import LogsController
-from util import require_env_var
+from cloudcompose.util import require_env_var
 import boto3
 import botocore
 from time import sleep

--- a/cloudcompose/cluster/aws/cloudwatch.py
+++ b/cloudcompose/cluster/aws/cloudwatch.py
@@ -1,6 +1,6 @@
 import botocore
 import boto3
-from util import require_env_var
+from cloudcompose.util import require_env_var
 from retrying import retry
 from os import environ
 

--- a/cloudcompose/cluster/aws/iam.py
+++ b/cloudcompose/cluster/aws/iam.py
@@ -1,7 +1,7 @@
 import boto3
 import botocore
 from cloudcompose.exceptions import CloudComposeException
-from util import require_env_var
+from cloudcompose.util import require_env_var
 from retrying import retry
 from os import environ
 

--- a/cloudcompose/cluster/aws/util.py
+++ b/cloudcompose/cluster/aws/util.py
@@ -1,8 +1,0 @@
-from cloudcompose.exceptions import CloudComposeException
-from os import environ
-
-def require_env_var(key):
-    if key not in environ:
-        raise CloudComposeException('Missing %s environment variable' % key)
-    return environ[key]
-

--- a/cloudcompose/cluster/cloudinit.py
+++ b/cloudcompose/cluster/cloudinit.py
@@ -2,29 +2,18 @@ from cloudcompose.cluster.template import Template
 from cloudcompose.cluster.dockercompose import DockerCompose
 from os.path import join, split
 from pprint import pprint
+from cloudcompose.cloudinit import CloudInit as BaseCloudInit
 
-class CloudInit():
+class CloudInit(BaseCloudInit):
     def __init__(self, base_dir='.'):
-        self.base_dir = base_dir
-        self.template_file = 'cluster.sh'
+        BaseCloudInit.__init__(self, 'cluster', base_dir)
 
-    def build(self, config_data, **kwargs):
-        raw_search_path = config_data['search_path']
-        raw_search_path.insert(0, '.')
-        search_path = [join(self.base_dir, path) for path in raw_search_path]
-        for key, value in kwargs.iteritems():
-            config_data['_' + key] = value
+    def build_pre_hook(self, config_data, **kwargs):
+        self._add_docker_compose(config_data)
 
-        self._add_docker_compose(config_data, search_path)
-        return self._render_template(config_data, search_path)
-
-    def _add_docker_compose(self, config_data, search_path):
-        docker_compose = DockerCompose(search_path)
+    def _add_docker_compose(self, config_data):
+        docker_compose = DockerCompose(self.search_path(config_data))
         docker_compose, docker_compose_override = docker_compose.yaml_files(config_data)
         config_data['docker_compose'] = {}
         config_data['docker_compose']['yaml'] = docker_compose
         config_data['docker_compose']['override_yaml'] = docker_compose_override
-
-    def _render_template(self, template_data, search_path):
-        template = Template(search_path)
-        return template.render(self.template_file, template_data)

--- a/cloudcompose/cluster/commands/cli.py
+++ b/cloudcompose/cluster/commands/cli.py
@@ -10,7 +10,8 @@ def cli():
 @cli.command()
 @click.option('--cloud-init/--no-cloud-init', default=True, help="Initialize the instance with a cloud init script")
 @click.option('--use-snapshots/--no-use-snapshots', default=True, help="Use snapshots to initialize volumes with existing data")
-def up(cloud_init, use_snapshots):
+@click.option('--upgrade-image/--no-upgrade-image', default=False, help="Upgrade the image to the newest version instead of keeping the cluster consistent")
+def up(cloud_init, use_snapshots, upgrade_image):
     """
     creates a new cluster
     """
@@ -21,7 +22,7 @@ def up(cloud_init, use_snapshots):
         ci = CloudInit()
 
     cloud_controller = CloudController(cloud_config)
-    cloud_controller.up(ci, use_snapshots)
+    cloud_controller.up(ci, use_snapshots, upgrade_image)
 
 @cli.command()
 def down():


### PR DESCRIPTION
Added support for cloud-compose-image plugin by moving some of the logic to cloud-compose and supporting references to ami by using the Tag name instead of the ID. 

**How was this tested?**
Create images for sandbox, wpit, and arc. Create mongodb clusters for each and checked replicaset health after launching.