### PR TITLE
Environment in cloud compose yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ cluster:
   search_path:
     - docker-mongodb
     - docker-mongodb/cloud-compose/templates
+  environment:
+    FOOBAR: "baz"
   aws:
     ami: ${IMAGE_ID}
     username: ${IMAGE_USERNAME}
@@ -84,6 +86,9 @@ The ``name`` is the unique name of this cluster. This is also added as a tag to 
 
 #### search_path 
 The ``search_path`` is the directories that will be examined when looking for configuration files like the ``cluster.sh`` file and the ``docker-compose.override.yml``.
+
+#### environment
+The ``environment`` is a list of environment variables that should be used when rendering the template files. This allows you to add environment options to a cluster and versioning them with the rest of your configs.
 
 #### AWS
 The AWS section contains information needed to create the cluster on AWS.

--- a/cloudcompose/cluster/cloudinit.py
+++ b/cloudcompose/cluster/cloudinit.py
@@ -1,6 +1,7 @@
 from cloudcompose.cluster.template import Template
 from cloudcompose.cluster.dockercompose import DockerCompose
 from os.path import join, split
+from os import environ
 from pprint import pprint
 from cloudcompose.cloudinit import CloudInit as BaseCloudInit
 
@@ -9,7 +10,13 @@ class CloudInit(BaseCloudInit):
         BaseCloudInit.__init__(self, 'cluster', base_dir)
 
     def build_pre_hook(self, config_data, **kwargs):
+        self._add_custom_environment(config_data)
         self._add_docker_compose(config_data)
+
+    def _add_custom_environment(self, config_data):
+        for key, val in config_data['environment'].iteritems():
+            if key not in environ:
+                environ[key] = val
 
     def _add_docker_compose(self, config_data):
         docker_compose = DockerCompose(self.search_path(config_data))

--- a/cloudcompose/cluster/cloudinit.py
+++ b/cloudcompose/cluster/cloudinit.py
@@ -14,7 +14,7 @@ class CloudInit(BaseCloudInit):
         self._add_docker_compose(config_data)
 
     def _add_custom_environment(self, config_data):
-        for key, val in config_data['environment'].iteritems():
+        for key, val in config_data.get('environment', {}).iteritems():
             if key not in environ:
                 environ[key] = val
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import warnings
 
 setup(
     name='cloud-compose-cluster',
-    version='0.4.2',
+    version='0.5.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
@@ -32,7 +32,7 @@ setup(
     author="Patrick Cullen and the WaPo platform tools team",
     author_email="opensource@washingtonpost.com",
     url="https://github.com/cloud-compose/cloud-compose-cluster",
-    download_url = "https://github.com/cloud-compose/cloud-compose-cluster/tarball/v0.4.2",
+    download_url = "https://github.com/cloud-compose/cloud-compose-cluster/tarball/v0.5.0",
     keywords = ['cloud', 'compose', 'aws'],
     classifiers = []
 )

--- a/tests/configs/simple/cloud-compose.yml
+++ b/tests/configs/simple/cloud-compose.yml
@@ -2,6 +2,8 @@ cluster:
   name: simple
   search_path:
     - templates
+  environment:
+    MONGODB_OPTIONS: "-h"
   aws:
     security_groups: sg-abc123
     volumes:

--- a/tests/configs/simple/cloud_init.sh
+++ b/tests/configs/simple/cloud_init.sh
@@ -20,4 +20,6 @@ mongodb:
     - "node0:10.0.10.10"
   volumes:
     - "/data/mongodb/mongodb:/data/db"
+  environment:
+    MONGODB_OPTIONS: "-h"
 EOF

--- a/tests/configs/simple/templates/docker-compose.override.yml
+++ b/tests/configs/simple/templates/docker-compose.override.yml
@@ -6,3 +6,7 @@ mongodb:
   {%- endfor %}
   volumes:
     - "/data/mongodb/mongodb:/data/db"
+  {%- if MONGODB_OPTIONS is defined %}
+  environment:
+    MONGODB_OPTIONS: "{{MONGODB_OPTIONS}}"
+  {%- endif %}


### PR DESCRIPTION
Added environment variables inside the cloud-compose.yml. If the environment variable is already present in the machine environment it will override the value in the cloud-compose.yml.

For example, if you want to configure a memcached cluster with a larger max item size you add the following to your cloud-compose.yml:

```yaml
cluster:
  environment:
    MEMCACHED_EXTRA_OPTIONS: "-I 10m"
```

** How was this tested? **
1. Created unit test for the environment variable in the cloud-compose.yml.
2. Created a memcached cluster using the environment option in the cloud-compose.
3. Verified that a local environment variable will take precedence over the cloud-compose value.