### PR TITLE
support io1 volume_type and iops configs

### DIFF
--- a/cloudcompose/cluster/aws/ebs.py
+++ b/cloudcompose/cluster/aws/ebs.py
@@ -54,6 +54,10 @@ class EBSController:
                 "VolumeType": volume.get("volume_type", "gp2")
             }
         }
+
+        if volume_config['Ebs']['VolumeType'] == 'io1':
+            volume_config['Ebs']['Iops'] = volume.get("iops", volume_config['Ebs']['VolumeSize']*30)
+
         if use_snapshots:
             self._add_snapshot_id(volume_config, volume, device)
 


### PR DESCRIPTION
Perso team need cloud-compose support for io1 volume type to help with some mongo issues. added a few lines with respect to the configs Howard Wang created.

if iops doesnt exist, i use Gib*30 as default after looking at this doc: http://docs.aws.amazon.com/cli/latest/reference/ec2/create-volume.html