### PR TITLE
Obscure key error running on python 2.7.13

### DIFF
--- a/cloudcompose/cluster/aws/cloudcontroller.py
+++ b/cloudcompose/cluster/aws/cloudcontroller.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
 from past.builtins import basestring
 from builtins import object
 from os import environ


### PR DESCRIPTION
With this import, on python 2.7.13, throws this stacktrace:
```
...
File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py", line 1299, in quote
    return ''.join(map(quoter, s))
KeyError: 80
```

Tested on python 2.7.13 and python 3.6